### PR TITLE
Let jobs fail on errors

### DIFF
--- a/mariadb-backup-template-with-icinga-and-secret.yaml
+++ b/mariadb-backup-template-with-icinga-and-secret.yaml
@@ -43,6 +43,7 @@ objects:
       concurrencyPolicy: Forbid
       jobTemplate:
         spec:
+          backoffLimit: 0
           template:
             spec:
               volumes:
@@ -58,7 +59,7 @@ objects:
                     - 'pipefail'
                     - '-c'
                     - > 
-                      trap "echo Backup failed; exit 0" ERR; 
+                      trap "echo Backup failed; exit 1" ERR;
                       FILENAME=backup-${DATABASE_NAME}-`date +%Y-%m-%d_%H%M%S`.sql.gz;
                       time (find /database-backup -type f -name "backup-${DATABASE_NAME}-*"  -exec ls -1tr "{}" + | head -n -${DATABASE_BACKUP_KEEP} | xargs rm -fr; 
                       mysqldump -u$DATABASE_USER -p$DATABASE_PASSWORD -h$DATABASE_HOST -P$DATABASE_PORT --skip-lock-tables --quick --add-drop-database --routines ${DATABASE_NAME} | gzip > /database-backup/$FILENAME); 

--- a/mariadb-backup-template-with-icinga.yaml
+++ b/mariadb-backup-template-with-icinga.yaml
@@ -46,6 +46,7 @@ objects:
       concurrencyPolicy: Forbid
       jobTemplate:
         spec:
+          backoffLimit: 0
           template:
             spec:
               volumes:
@@ -61,7 +62,7 @@ objects:
                     - 'pipefail'
                     - '-c'
                     - > 
-                      trap "echo Backup failed; exit 0" ERR; 
+                      trap "echo Backup failed; exit 1" ERR;
                       FILENAME=backup-${DATABASE_NAME}-`date +%Y-%m-%d_%H%M%S`.sql.gz;
                       time (find /database-backup -type f -name "backup-${DATABASE_NAME}-*"  -exec ls -1tr "{}" + | head -n -${DATABASE_BACKUP_KEEP} | xargs rm -fr; 
                       mysqldump -u$DATABASE_USER -p$DATABASE_PASSWORD -h$DATABASE_HOST -P$DATABASE_PORT --skip-lock-tables --quick --add-drop-database --routines ${DATABASE_NAME} | gzip > /database-backup/$FILENAME); 

--- a/mariadb-backup-template-with-secret.yaml
+++ b/mariadb-backup-template-with-secret.yaml
@@ -37,6 +37,7 @@ objects:
       concurrencyPolicy: Forbid
       jobTemplate:
         spec:
+          backoffLimit: 0
           template:
             spec:
               volumes:
@@ -52,7 +53,7 @@ objects:
                     - 'pipefail'
                     - '-c'
                     - > 
-                      trap "echo Backup failed; exit 0" ERR; 
+                      trap "echo Backup failed; exit 1" ERR;
                       FILENAME=backup-${DATABASE_NAME}-`date +%Y-%m-%d_%H%M%S`.sql.gz;
                       time (find /database-backup -type f -name "backup-${DATABASE_NAME}-*"  -exec ls -1tr "{}" + | head -n -${DATABASE_BACKUP_KEEP} | xargs rm -fr; 
                       mysqldump -u$DATABASE_USER -p$DATABASE_PASSWORD -h$DATABASE_HOST -P$DATABASE_PORT --skip-lock-tables --quick --add-drop-database --routines ${DATABASE_NAME} | gzip > /database-backup/$FILENAME); 


### PR DESCRIPTION
The exit trap causes Job Pods to be in state "Completed" even if the backup failed (e.g. because of wrong credentials). If that's not by design, I propose this change, which leads to the jobs' Pods ending up in state "Error" in case of problems.